### PR TITLE
Add Stripe subscription setup

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,0 +1,26 @@
+class SubscriptionsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_team
+
+  def create
+    price_id = ENV['STRIPE_PRO_PLAN_PRICE_ID']
+    session = Stripe::Checkout::Session.create(
+      mode: 'subscription',
+      customer_email: current_user.email,
+      line_items: [
+        { price: price_id, quantity: 1 }
+      ],
+      metadata: { team_id: @team.id },
+      success_url: team_settings_url(@team, section: 'billing', session_id: '{CHECKOUT_SESSION_ID}'),
+      cancel_url: team_settings_url(@team, section: 'billing')
+    )
+
+    redirect_to session.url, allow_other_host: true, status: 303
+  end
+
+  private
+
+  def set_team
+    @team = current_user.teams.find(params[:team_id])
+  end
+end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,0 +1,5 @@
+class Subscription < ApplicationRecord
+  belongs_to :team
+
+  validates :plan, presence: true
+end

--- a/app/views/settings/_billing.html.erb
+++ b/app/views/settings/_billing.html.erb
@@ -10,15 +10,11 @@
     <p class="mt-1"><%= t('settings.billing.current_plan.description') %></p>
   </div>
   <div class="mt-4">
-    <% if I18n.locale == :'pt-BR' %>
-      <%= link_to ENV['STRIPE_PRO_PLAN_BR_URL'], class: "inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-purple-600 hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-purple-500", target: "_blank" do %>
-        <%= t('settings.billing.current_plan.upgrade_button') %>
-      <% end %>
-    <% else %>
-      <%= link_to ENV['STRIPE_PRO_PLAN_WORLDWIDE_URL'], class: "inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-purple-600 hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-purple-500", target: "_blank" do %>
-        <%= t('settings.billing.current_plan.upgrade_button') %>
-      <% end %>
-    <% end %>
+    <%= button_to t('settings.billing.current_plan.upgrade_button'),
+                  team_subscription_path(@team),
+                  method: :post,
+                  class: "inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-purple-600 hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-purple-500",
+                  form: { data: { turbo: false } } %>
     <span class="ml-2 text-sm text-gray-500"><%= t('settings.billing.current_plan.cancel_notice') %></span>
   </div>
 </div>
@@ -90,13 +86,11 @@
         <span class="ml-2 text-sm text-gray-500"><%= t('settings.billing.plans.free.features.support') %></span>
       </li>
     </ul>
-    <button class="mt-8 w-full bg-purple-600 text-white px-4 py-2 rounded-md text-sm font-medium hover:bg-purple-700">
-      <% if I18n.locale == :'pt-BR' %>
-        <%= link_to t('settings.billing.plans.pro.upgrade_button'), ENV['STRIPE_PRO_PLAN_BR_URL'], class: "block w-full text-center", target: "_blank" %>
-      <% else %>
-        <%= link_to t('settings.billing.plans.pro.upgrade_button'), ENV['STRIPE_PRO_PLAN_WORLDWIDE_URL'], class: "block w-full text-center", target: "_blank" %>
-      <% end %>
-    </button>
+    <%= button_to t('settings.billing.plans.pro.upgrade_button'),
+                  team_subscription_path(@team),
+                  method: :post,
+                  class: "mt-8 w-full bg-purple-600 text-white px-4 py-2 rounded-md text-sm font-medium hover:bg-purple-700 block text-center",
+                  form: { data: { turbo: false } } %>
   </div>
 
   <!-- Enterprise Plan -->

--- a/config/initializers/stripe.rb
+++ b/config/initializers/stripe.rb
@@ -1,0 +1,1 @@
+Stripe.api_key = ENV['STRIPE_SECRET_KEY']

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,7 @@ Rails.application.routes.draw do
       end
     end
     resource :settings, only: [:show]
+    resource :subscription, only: [:create]
     resources :locations
   end
   get 'team_selection', to: 'teams#selection'

--- a/db/migrate/20250323232145_create_subscriptions.rb
+++ b/db/migrate/20250323232145_create_subscriptions.rb
@@ -1,0 +1,14 @@
+class CreateSubscriptions < ActiveRecord::Migration[8.0]
+  def change
+    create_table :subscriptions do |t|
+      t.references :team, null: false, foreign_key: true
+      t.string :stripe_customer_id
+      t.string :stripe_subscription_id
+      t.string :plan
+      t.string :status
+      t.datetime :current_period_end
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :subscription do
+    plan { 'pro' }
+    status { 'active' }
+    association :team
+  end
+end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Subscription, type: :model do
+  describe 'associations' do
+    it { should belong_to(:team) }
+  end
+
+  describe 'validations' do
+    it { should validate_presence_of(:plan) }
+  end
+
+  describe 'factory' do
+    it 'has a valid factory' do
+      expect(build(:subscription)).to be_valid
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add Stripe initializer
- create `subscriptions` table and model
- route and controller to start Stripe checkout
- integrate checkout buttons in billing UI
- add subscription factory and specs

## Testing
- `bundle exec rspec` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68700d835acc833382e916a7201ee4e1