### PR TITLE
Add RSpec model and request specs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,10 @@ jobs:
           RAILS_ENV: test
           DATABASE_URL: postgres://postgres:postgres@localhost:5432
           # REDIS_URL: redis://localhost:6379/0
-        run: bin/rails db:test:prepare test test:system
+        run: |
+          bin/rails db:test:prepare
+          bundle exec rspec
+          bin/rails test test:system
 
       - name: Keep screenshots from failed system tests
         uses: actions/upload-artifact@v4

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :item do
+    association :team
+    association :location, factory: :location, team: team
+    sequence(:name) { |n| "Item #{n}" }
+    sequence(:sku) { |n| "SKU#{n}" }
+    sequence(:barcode) { |n| "BC#{n}" }
+    cost { 1.0 }
+    price { 2.0 }
+    item_type { 'Type' }
+    brand { 'Brand' }
+    initial_quantity { 1 }
+  end
+end

--- a/spec/factories/locations.rb
+++ b/spec/factories/locations.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :location do
+    association :team
+    sequence(:name) { |n| "Location #{n}" }
+    description { "Test location" }
+  end
+end

--- a/spec/factories/stock_transactions.rb
+++ b/spec/factories/stock_transactions.rb
@@ -1,0 +1,21 @@
+FactoryBot.define do
+  factory :stock_transaction do
+    association :item
+    team { item.team }
+    user { team.user }
+    transaction_type { 'stock_in' }
+    quantity { 1 }
+    destination_location { association :location, team: team }
+
+    trait :stock_out do
+      transaction_type { 'stock_out' }
+      quantity { -1 }
+      destination_location { nil }
+      source_location { association :location, team: team }
+    end
+
+    trait :adjust do
+      transaction_type { 'adjust' }
+    end
+  end
+end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe Item, type: :model do
+  describe 'associations' do
+    it { should belong_to(:team) }
+    it { should belong_to(:location).optional }
+    it { should have_many(:stock_transactions).dependent(:destroy) }
+  end
+
+  describe 'validations' do
+    subject { build(:item) }
+
+    it { should validate_presence_of(:name) }
+    it { should validate_presence_of(:sku) }
+    it { should validate_uniqueness_of(:sku).scoped_to(:team_id) }
+    it { should validate_presence_of(:item_type) }
+    it { should validate_presence_of(:initial_quantity) }
+    it { should validate_numericality_of(:initial_quantity).is_greater_than_or_equal_to(0) }
+    it { should validate_presence_of(:price) }
+    it { should validate_numericality_of(:price).is_greater_than_or_equal_to(0) }
+    it { should validate_presence_of(:cost) }
+    it { should validate_numericality_of(:cost).is_greater_than_or_equal_to(0) }
+  end
+
+  describe 'location validation' do
+    it 'is invalid if location belongs to another team' do
+      other_team = create(:team)
+      item = build(:item, team: create(:team), location: create(:location, team: other_team))
+      expect(item).not_to be_valid
+      expect(item.errors[:location_id]).to be_present
+    end
+  end
+
+  describe '#current_stock' do
+    it 'calculates the sum of transaction quantities' do
+      item = create(:item, initial_quantity: 0)
+      loc = item.location
+      create(:stock_transaction, item: item, team: item.team, user: item.team.user, quantity: 10, destination_location: loc)
+      create(:stock_transaction, :stock_out, item: item, team: item.team, user: item.team.user, source_location: loc)
+      create(:stock_transaction, :adjust, item: item, team: item.team, user: item.team.user, quantity: 3, destination_location: loc)
+      expect(item.current_stock).to eq(12)
+    end
+  end
+end

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe Location, type: :model do
+  describe 'associations' do
+    it { should belong_to(:team) }
+    it { should have_many(:items).dependent(:nullify) }
+    it { should have_many(:source_transactions).class_name('StockTransaction').with_foreign_key('source_location_id') }
+    it { should have_many(:destination_transactions).class_name('StockTransaction').with_foreign_key('destination_location_id') }
+  end
+
+  describe 'validations' do
+    subject { build(:location) }
+
+    it { should validate_presence_of(:name) }
+    it { should validate_uniqueness_of(:name).scoped_to(:team_id) }
+  end
+
+  describe '.ordered' do
+    it 'returns locations ordered by name' do
+      l1 = create(:location, name: 'B')
+      l2 = create(:location, name: 'A')
+      expect(Location.ordered).to eq([l2, l1])
+    end
+  end
+end

--- a/spec/models/stock_transaction_spec.rb
+++ b/spec/models/stock_transaction_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe StockTransaction, type: :model do
+  describe 'associations' do
+    it { should belong_to(:item) }
+    it { should belong_to(:team) }
+    it { should belong_to(:user) }
+    it { should belong_to(:source_location).class_name('Location').optional }
+    it { should belong_to(:destination_location).class_name('Location').optional }
+  end
+
+  describe 'validations' do
+    subject { build(:stock_transaction) }
+
+    it { should validate_presence_of(:quantity) }
+    it { should validate_presence_of(:transaction_type) }
+  end
+
+  context 'stock_in' do
+    let(:transaction) { build(:stock_transaction) }
+
+    it 'requires destination_location' do
+      transaction.destination_location = nil
+      expect(transaction).not_to be_valid
+    end
+  end
+
+  context 'stock_out' do
+    let(:transaction) { build(:stock_transaction, :stock_out) }
+
+    it 'requires source_location' do
+      transaction.source_location = nil
+      expect(transaction).not_to be_valid
+    end
+
+    it 'requires negative quantity' do
+      transaction.quantity = 1
+      expect(transaction).not_to be_valid
+    end
+  end
+end

--- a/spec/requests/items_spec.rb
+++ b/spec/requests/items_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe "Items", type: :request do
+  let(:user) { create(:user) }
+  let(:team) { create(:team, user: user) }
+  let(:location) { create(:location, team: team) }
+
+  before do
+    sign_in user
+  end
+
+  describe "GET /teams/:team_id/items" do
+    it "returns success" do
+      get team_items_path(team)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "POST /teams/:team_id/items" do
+    it "creates an item" do
+      expect {
+        post team_items_path(team), params: { item: attributes_for(:item, location_id: location.id, team_id: team.id) }
+      }.to change(Item, :count).by(1)
+      expect(response).to redirect_to(team_items_path(team))
+    end
+
+    it "renders errors with invalid params" do
+      expect {
+        post team_items_path(team), params: { item: { name: "" } }
+      }.not_to change(Item, :count)
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+end

--- a/spec/requests/stock_transactions_spec.rb
+++ b/spec/requests/stock_transactions_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe "StockTransactions", type: :request do
+  let(:user) { create(:user) }
+  let(:team) { create(:team, user: user) }
+  let(:location) { create(:location, team: team) }
+  let(:item) { create(:item, team: team, location: location) }
+
+  before do
+    sign_in user
+  end
+
+  describe "POST /teams/:team_id/transactions/stock_in" do
+    it "creates a stock transaction" do
+      expect {
+        post stock_in_team_stock_transactions_path(team), params: { location: location.id, items: [{ id: item.id, quantity: 2 }], notes: "" }, as: :json
+      }.to change(StockTransaction, :count).by(1)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add factories for item, location and stock transaction
- create model specs for Item, Location and StockTransaction
- add request specs for items and stock transactions
- update CI workflow to run RSpec suite

## Testing
- `bundle exec rspec` *(fails: `bundler: command not found: rspec`)*
- `bin/rubocop --fail-level F` *(fails: Bundler::GitError)*

------
https://chatgpt.com/codex/tasks/task_b_687018613f148333b3e6d8344653beb6