### PR TITLE
Add system spec for user login

### DIFF
--- a/spec/system/user_signs_in_spec.rb
+++ b/spec/system/user_signs_in_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe 'User sign in', type: :system do
+  it 'allows a user to sign in' do
+    user = create(:user)
+
+    visit new_user_session_path
+    fill_in 'E-mail', with: user.email
+    fill_in 'Senha', with: 'password123'
+    click_button 'Entrar'
+
+    expect(page).to have_content(I18n.t('teams.selection.title'))
+  end
+end


### PR DESCRIPTION
## Summary
- add a basic Capybara system spec to test signing in via the UI

## Testing
- `bin/rubocop` *(fails: ruby 3.2.2 not installed)*
- `bin/brakeman --no-pager` *(fails: ruby 3.2.2 not installed)*
- `bin/importmap audit` *(fails: ruby 3.2.2 not installed)*
- `bin/rails db:test:prepare` *(fails: ruby 3.2.2 not installed)*
- `bin/rails test` *(fails: ruby 3.2.2 not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6870fcf2dc6083339e59350223bc3e32