### PR TITLE
Add mobile sidebar toggle

### DIFF
--- a/app/javascript/controllers/sidebar_controller.js
+++ b/app/javascript/controllers/sidebar_controller.js
@@ -2,7 +2,10 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   static targets = ["sidebar", "text", "toggleIcon"]
-  static values = { expanded: { type: Boolean, default: true } }
+  static values = {
+    expanded: { type: Boolean, default: true },
+    mobileVisible: { type: Boolean, default: false }
+  }
 
   connect() {
     this.expandedValue = true
@@ -41,4 +44,17 @@ export default class extends Controller {
       })
     }
   }
-} 
+
+  toggleMobile() {
+    this.mobileVisibleValue = !this.mobileVisibleValue
+
+    if (this.mobileVisibleValue) {
+      this.sidebarTarget.classList.remove("hidden", "-translate-x-full")
+      this.sidebarTarget.classList.add("translate-x-0")
+    } else {
+      this.sidebarTarget.classList.remove("translate-x-0")
+      this.sidebarTarget.classList.add("-translate-x-full")
+      setTimeout(() => this.sidebarTarget.classList.add("hidden"), 300)
+    }
+  }
+}

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,6 +1,12 @@
 <header class="bg-white shadow-sm">
     <div class="flex items-center justify-between h-16">
       <div class="flex items-center">
+        <button data-action="click->sidebar#toggleMobile" class="md:hidden mr-2 text-gray-600 hover:text-gray-900">
+          <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/>
+          </svg>
+        </button>
+
         <%= link_to root_path, class: "flex items-center" do %>
           <%= tag.svg xmlns: "http://www.w3.org/2000/svg", width: "300", height: "60", viewBox: "0 0 1500 360" do %>
             <g transform="translate(100, 200) scale(1.2)">

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -1,5 +1,7 @@
 <div data-controller="sidebar" class="relative">
-  <div data-sidebar-target="sidebar" class="w-64 bg-white border-r border-gray-200 min-h-screen transition-all duration-300">
+  <div
+    data-sidebar-target="sidebar"
+    class="fixed inset-y-0 left-0 z-50 w-64 bg-white border-r border-gray-200 min-h-screen transition-transform duration-300 -translate-x-full md:relative md:translate-x-0 md:block hidden">
     <div class="flex flex-col h-full">
       <div class="p-4 border-b border-gray-200">
         <%= link_to team_selection_path, 
@@ -27,9 +29,9 @@
       </div>
 
       <div class="flex-1 flex flex-col pt-5 pb-4 overflow-y-auto">
-        <button 
+        <button
           data-action="click->sidebar#toggle"
-          class="absolute -right-3 top-8 bg-white border border-gray-200 rounded-full p-1.5 shadow-sm">
+          class="absolute -right-3 top-8 bg-white border border-gray-200 rounded-full p-1.5 shadow-sm hidden md:block">
           <svg 
             data-sidebar-target="toggleIcon"
             class="w-4 h-4 text-gray-400 transform transition-transform duration-300" 


### PR DESCRIPTION
## Summary
- add a menu button in the header
- make sidebar hidden on mobile
- support mobile sidebar toggling in JS controller

## Testing
- `bin/rubocop` *(fails: ruby 3.2.2 not installed)*
- `bin/brakeman --no-pager` *(fails: ruby 3.2.2 not installed)*
- `bin/importmap audit` *(fails: ruby 3.2.2 not installed)*
- `bin/rails db:test:prepare` *(fails: ruby 3.2.2 not installed)*
- `bin/rails test` *(fails: ruby 3.2.2 not installed)*

------
https://chatgpt.com/codex/tasks/task_b_687100d8d5608333bd3f84742f2f6cfa