### PR TITLE
Add password visibility toggle

### DIFF
--- a/app/javascript/controllers/password_visibility_controller.js
+++ b/app/javascript/controllers/password_visibility_controller.js
@@ -3,9 +3,13 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = ["input", "eye", "eyeSlash"]
 
-  toggle() {
+  toggle(event) {
+    event.preventDefault()
+    event.stopPropagation()
+
     const type = this.inputTarget.type === "password" ? "text" : "password"
     this.inputTarget.type = type
+
     if (this.hasEyeTarget && this.hasEyeSlashTarget) {
       this.eyeTarget.classList.toggle("hidden", type === "text")
       this.eyeSlashTarget.classList.toggle("hidden", type === "password")

--- a/app/javascript/controllers/password_visibility_controller.js
+++ b/app/javascript/controllers/password_visibility_controller.js
@@ -1,0 +1,14 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["input", "eye", "eyeSlash"]
+
+  toggle() {
+    const type = this.inputTarget.type === "password" ? "text" : "password"
+    this.inputTarget.type = type
+    if (this.hasEyeTarget && this.hasEyeSlashTarget) {
+      this.eyeTarget.classList.toggle("hidden", type === "text")
+      this.eyeSlashTarget.classList.toggle("hidden", type === "password")
+    }
+  }
+}

--- a/app/javascript/controllers/password_visibility_controller.js
+++ b/app/javascript/controllers/password_visibility_controller.js
@@ -5,14 +5,15 @@ export default class extends Controller {
 
   toggle(event) {
     event.preventDefault()
-    event.stopPropagation()
 
-    const type = this.inputTarget.type === "password" ? "text" : "password"
+    const show = this.inputTarget.type === "password"
+    const type = show ? "text" : "password"
     this.inputTarget.type = type
+    this.inputTarget.setAttribute("type", type)
 
     if (this.hasEyeTarget && this.hasEyeSlashTarget) {
-      this.eyeTarget.classList.toggle("hidden", type === "text")
-      this.eyeSlashTarget.classList.toggle("hidden", type === "password")
+      this.eyeTarget.classList.toggle("hidden", show)
+      this.eyeSlashTarget.classList.toggle("hidden", !show)
     }
   }
 }

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -36,8 +36,20 @@
 
         <div>
           <%= f.label :password, "Senha", class: "block text-sm font-bold mb-2 text-gray-700" %>
-          <%= f.password_field :password, autocomplete: "new-password",
-              class: "w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-600 focus:border-transparent text-base" %>
+          <div data-controller="password-visibility" class="relative">
+            <%= f.password_field :password, autocomplete: "new-password",
+                class: "w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-600 focus:border-transparent text-base",
+                data: { password_visibility_target: "input" } %>
+            <button type="button" data-action="password-visibility#toggle" class="absolute inset-y-0 right-0 pr-3 flex items-center">
+              <svg data-password-visibility-target="eye" class="h-5 w-5 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.477 0 8.268 2.943 9.542 7-1.274 4.057-5.065 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+              </svg>
+              <svg data-password-visibility-target="eyeSlash" class="h-5 w-5 text-gray-500 hidden" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.477 0-8.268-2.943-9.542-7a9.961 9.961 0 013.619-5.361M8.712 4.712A9.953 9.953 0 0112 5c4.477 0 8.268 2.943 9.542 7a9.961 9.961 0 01-4.569 5.569M15 12a3 3 0 11-6 0 3 3 0 016 0zM3 3l18 18" />
+              </svg>
+            </button>
+          </div>
           <% if @minimum_password_length %>
             <p class="mt-1 text-sm text-gray-500">Mínimo <%= @minimum_password_length %> caracteres</p>
           <% end %>
@@ -45,8 +57,20 @@
 
         <div>
           <%= f.label :password_confirmation, "Confirmar Senha", class: "block text-sm font-bold mb-2 text-gray-700" %>
-          <%= f.password_field :password_confirmation, autocomplete: "new-password",
-              class: "w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-600 focus:border-transparent text-base" %>
+          <div data-controller="password-visibility" class="relative">
+            <%= f.password_field :password_confirmation, autocomplete: "new-password",
+                class: "w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-600 focus:border-transparent text-base",
+                data: { password_visibility_target: "input" } %>
+            <button type="button" data-action="password-visibility#toggle" class="absolute inset-y-0 right-0 pr-3 flex items-center">
+              <svg data-password-visibility-target="eye" class="h-5 w-5 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.477 0 8.268 2.943 9.542 7-1.274 4.057-5.065 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+              </svg>
+              <svg data-password-visibility-target="eyeSlash" class="h-5 w-5 text-gray-500 hidden" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.477 0-8.268-2.943-9.542-7a9.961 9.961 0 013.619-5.361M8.712 4.712A9.953 9.953 0 0112 5c4.477 0 8.268 2.943 9.542 7a9.961 9.961 0 01-4.569 5.569M15 12a3 3 0 11-6 0 3 3 0 016 0zM3 3l18 18" />
+              </svg>
+            </button>
+          </div>
         </div>
 
         <%= f.submit "Criar conta",

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -41,11 +41,11 @@
                 class: "w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-600 focus:border-transparent text-base",
                 data: { password_visibility_target: "input" } %>
             <button type="button" data-action="password-visibility#toggle" class="absolute inset-y-0 right-0 pr-3 flex items-center">
-              <svg data-password-visibility-target="eye" class="h-5 w-5 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <svg data-password-visibility-target="eye" class="h-5 w-5 text-gray-500 pointer-events-none" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.477 0 8.268 2.943 9.542 7-1.274 4.057-5.065 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
               </svg>
-              <svg data-password-visibility-target="eyeSlash" class="h-5 w-5 text-gray-500 hidden" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <svg data-password-visibility-target="eyeSlash" class="h-5 w-5 text-gray-500 hidden pointer-events-none" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.477 0-8.268-2.943-9.542-7a9.961 9.961 0 013.619-5.361M8.712 4.712A9.953 9.953 0 0112 5c4.477 0 8.268 2.943 9.542 7a9.961 9.961 0 01-4.569 5.569M15 12a3 3 0 11-6 0 3 3 0 016 0zM3 3l18 18" />
               </svg>
             </button>
@@ -62,11 +62,11 @@
                 class: "w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-600 focus:border-transparent text-base",
                 data: { password_visibility_target: "input" } %>
             <button type="button" data-action="password-visibility#toggle" class="absolute inset-y-0 right-0 pr-3 flex items-center">
-              <svg data-password-visibility-target="eye" class="h-5 w-5 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <svg data-password-visibility-target="eye" class="h-5 w-5 text-gray-500 pointer-events-none" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.477 0 8.268 2.943 9.542 7-1.274 4.057-5.065 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
               </svg>
-              <svg data-password-visibility-target="eyeSlash" class="h-5 w-5 text-gray-500 hidden" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <svg data-password-visibility-target="eyeSlash" class="h-5 w-5 text-gray-500 hidden pointer-events-none" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.477 0-8.268-2.943-9.542-7a9.961 9.961 0 013.619-5.361M8.712 4.712A9.953 9.953 0 0112 5c4.477 0 8.268 2.943 9.542 7a9.961 9.961 0 01-4.569 5.569M15 12a3 3 0 11-6 0 3 3 0 016 0zM3 3l18 18" />
               </svg>
             </button>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -45,11 +45,11 @@
                 class: "w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-600 focus:border-transparent text-base",
                 data: { password_visibility_target: "input" } %>
             <button type="button" data-action="password-visibility#toggle" class="absolute inset-y-0 right-0 pr-3 flex items-center">
-              <svg data-password-visibility-target="eye" class="h-5 w-5 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <svg data-password-visibility-target="eye" class="h-5 w-5 text-gray-500 pointer-events-none" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.477 0 8.268 2.943 9.542 7-1.274 4.057-5.065 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
               </svg>
-              <svg data-password-visibility-target="eyeSlash" class="h-5 w-5 text-gray-500 hidden" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <svg data-password-visibility-target="eyeSlash" class="h-5 w-5 text-gray-500 hidden pointer-events-none" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.477 0-8.268-2.943-9.542-7a9.961 9.961 0 013.619-5.361M8.712 4.712A9.953 9.953 0 0112 5c4.477 0 8.268 2.943 9.542 7a9.961 9.961 0 01-4.569 5.569M15 12a3 3 0 11-6 0 3 3 0 016 0zM3 3l18 18" />
               </svg>
             </button>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -37,11 +37,23 @@
         <div>
           <div class="flex items-center justify-between mb-2">
             <%= f.label :password, "Senha", class: "block text-sm font-bold text-gray-700" %>
-            <%= link_to "Esqueceu a senha?", new_password_path(resource_name), 
+            <%= link_to "Esqueceu a senha?", new_password_path(resource_name),
                 class: "text-sm text-purple-600 hover:text-purple-800 font-semibold" %>
           </div>
-          <%= f.password_field :password, autocomplete: "current-password",
-              class: "w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-600 focus:border-transparent text-base" %>
+          <div data-controller="password-visibility" class="relative">
+            <%= f.password_field :password, autocomplete: "current-password",
+                class: "w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-600 focus:border-transparent text-base",
+                data: { password_visibility_target: "input" } %>
+            <button type="button" data-action="password-visibility#toggle" class="absolute inset-y-0 right-0 pr-3 flex items-center">
+              <svg data-password-visibility-target="eye" class="h-5 w-5 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.477 0 8.268 2.943 9.542 7-1.274 4.057-5.065 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+              </svg>
+              <svg data-password-visibility-target="eyeSlash" class="h-5 w-5 text-gray-500 hidden" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.477 0-8.268-2.943-9.542-7a9.961 9.961 0 013.619-5.361M8.712 4.712A9.953 9.953 0 0112 5c4.477 0 8.268 2.943 9.542 7a9.961 9.961 0 01-4.569 5.569M15 12a3 3 0 11-6 0 3 3 0 016 0zM3 3l18 18" />
+              </svg>
+            </button>
+          </div>
         </div>
 
         <%= f.submit "Entrar", 


### PR DESCRIPTION
## Summary
- add a Stimulus controller to toggle password visibility
- allow showing/hiding passwords on the sign in and sign up forms

## Testing
- `bin/rubocop` *(fails: ruby-3.2.2 not installed)*
- `bin/brakeman --no-pager` *(fails: ruby-3.2.2 not installed)*
- `bin/importmap audit` *(fails: ruby-3.2.2 not installed)*
- `bin/rails db:test:prepare` *(fails: ruby-3.2.2 not installed)*
- `bin/rails test` *(fails: ruby-3.2.2 not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68717b50bef08333abfcca82364bc12a