### PR TITLE
Add dark mode toggle

### DIFF
--- a/app/javascript/controllers/theme_controller.js
+++ b/app/javascript/controllers/theme_controller.js
@@ -1,0 +1,36 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["label"]
+  static values = { lightLabel: String, darkLabel: String }
+
+  connect() {
+    this.applyPreference()
+    this.updateLabel()
+  }
+
+  toggle() {
+    document.documentElement.classList.toggle("dark")
+    this.savePreference()
+    this.updateLabel()
+  }
+
+  applyPreference() {
+    const stored = localStorage.getItem("theme")
+    if (stored === "dark") {
+      document.documentElement.classList.add("dark")
+    } else if (stored === "light") {
+      document.documentElement.classList.remove("dark")
+    }
+  }
+
+  savePreference() {
+    const mode = document.documentElement.classList.contains("dark") ? "dark" : "light"
+    localStorage.setItem("theme", mode)
+  }
+
+  updateLabel() {
+    const dark = document.documentElement.classList.contains("dark")
+    this.labelTarget.textContent = dark ? this.darkLabelValue : this.lightLabelValue
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,7 +25,7 @@
     <%= javascript_importmap_tags %>
   </head>
 
-  <body>
+  <body class="dark:bg-gray-900">
     <% if notice %>
       <p class="notice bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative" role="alert"><%= notice %></p>
     <% end %>

--- a/app/views/layouts/authenticated.html.erb
+++ b/app/views/layouts/authenticated.html.erb
@@ -10,7 +10,7 @@
     <%= javascript_importmap_tags %>
   </head>
 
-  <body class="bg-gray-50">
+  <body class="bg-gray-50 dark:bg-gray-900">
     <%= render "shared/header" %>
     
     <div class="flex">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,4 +1,4 @@
-<header class="bg-white shadow-sm">
+<header class="bg-white shadow-sm dark:bg-gray-800 dark:text-white">
     <div class="flex items-center justify-between h-16">
       <div class="flex items-center">
         <%= link_to root_path, class: "flex items-center" do %>
@@ -21,8 +21,8 @@
 
       <div class="flex items-center space-x-4">
         <% if @team.present? && @team.persisted? && !@hide_team_settings %>
-          <%= link_to team_settings_path(@team, section: 'billing'), 
-              class: "text-gray-600 hover:text-gray-900" do %>
+          <%= link_to team_settings_path(@team, section: 'billing'),
+              class: "text-gray-600 hover:text-gray-900 dark:text-gray-200 dark:hover:text-white" do %>
             <div class="flex items-center">
               <svg class="w-5 h-5 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 9V7a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2m2 4h10a2 2 0 002-2v-6a2 2 0 00-2-2H9a2 2 0 00-2 2v6a2 2 0 002 2zm7-5a2 2 0 11-4 0 2 2 0 014 0z"/>
@@ -35,10 +35,18 @@
         <div class="flex items-center space-x-2">
           <!-- Language Switcher -->
           <%= render 'shared/language_switcher' %>
+
+          <button data-controller="theme"
+                  data-action="click->theme#toggle"
+                  data-theme-light-label="<%= t('header.theme.dark') %>"
+                  data-theme-dark-label="<%= t('header.theme.light') %>"
+                  class="px-3 py-2 text-sm font-medium text-gray-700 hover:text-gray-900 dark:text-gray-200 dark:hover:text-white">
+            <span data-theme-target="label"><%= t('header.theme.dark') %></span>
+          </button>
           
-          <%= button_to destroy_user_session_path, 
+          <%= button_to destroy_user_session_path,
               method: :delete,
-              class: "flex items-center px-3 py-2 text-sm font-medium text-gray-700 hover:text-gray-900" do %>
+              class: "flex items-center px-3 py-2 text-sm font-medium text-gray-700 hover:text-gray-900 dark:text-gray-200 dark:hover:text-white" do %>
             <svg class="w-5 h-5 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"/>
             </svg>

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  darkMode: "class",
+  content: [
+    "./app/helpers/**/*.rb",
+    "./app/javascript/**/*.js",
+    "./app/views/**/*"
+  ],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+}


### PR DESCRIPTION
## Summary
- add Stimulus controller for theme switching
- configure Tailwind for class-based dark mode
- expose dark mode toggle button in header
- update layouts to respect dark theme

## Testing
- `bin/rubocop` *(fails: ruby-3.2.2 not installed)*
- `bin/brakeman --no-pager` *(fails: ruby-3.2.2 not installed)*
- `bin/importmap audit` *(fails: ruby-3.2.2 not installed)*
- `bin/rails db:test:prepare` *(fails: ruby-3.2.2 not installed)*
- `bin/rails test` *(fails: ruby-3.2.2 not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68718f47b8c48333b4f5cb4638474883