### PR TITLE
Add devise form flash messages

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -27,6 +27,7 @@
       <p class="text-gray-600 text-base mb-8">Digite suas credenciais para acessar sua conta</p>
 
       <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "space-y-6" }) do |f| %>
+        <%= render "devise/shared/error_messages", resource: resource %>
         <div>
           <%= f.label :email, "E-mail", class: "block text-sm font-bold mb-2 text-gray-700" %>
           <%= f.email_field :email, autofocus: true, autocomplete: "email", 


### PR DESCRIPTION
## Summary
- show validation errors on Devise login form

## Testing
- `bin/rubocop` *(fails: ruby-3.2.2 is not installed)*
- `bin/brakeman --no-pager` *(fails: ruby-3.2.2 is not installed)*
- `bin/importmap audit` *(fails: ruby-3.2.2 is not installed)*
- `bin/rails db:test:prepare` *(fails: ruby-3.2.2 is not installed)*
- `bin/rails test` *(fails: ruby-3.2.2 is not installed)*

------
https://chatgpt.com/codex/tasks/task_b_687197119d2c83338fbc7caf084a5cd1