### PR TITLE
Add CSV import for items

### DIFF
--- a/app/views/items/import.html.erb
+++ b/app/views/items/import.html.erb
@@ -1,0 +1,15 @@
+<div class="min-h-screen bg-gray-50">
+  <div class="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <h1 class="text-2xl font-bold mb-6"><%= t('items.index.import_csv', default: 'Import Items') %></h1>
+
+    <%= form_with url: import_team_items_path(@team), method: :post, local: true, html: { multipart: true }, class: "space-y-6" do |f| %>
+      <div>
+        <%= f.label :file, t('items.import.file', default: 'CSV File'), class: 'block text-sm font-medium text-gray-700' %>
+        <%= f.file_field :file, class: 'mt-1 block w-full border-gray-300 rounded-md shadow-sm' %>
+      </div>
+      <div class="flex justify-end">
+        <%= f.submit t('items.import.submit', default: 'Import'), class: 'btn btn-primary' %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -172,6 +172,10 @@ en:
         notes: "Notes"
         at: "At"
         from: "From"
+    import:
+      success: "Items imported successfully."
+      invalid: "Failed to import items."
+      no_file: "Please upload a CSV file."
   locations:
     index:
       title: "Locations"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -151,6 +151,10 @@ fr:
         notes: "Notes"
         at: "À"
         from: "De"
+    import:
+      success: "Articles importés avec succès."
+      invalid: "Échec de l'import des articles."
+      no_file: "Veuillez télécharger un fichier CSV."
   locations:
     index:
       title: "Emplacements"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -141,6 +141,10 @@ pt-BR:
         notes: "Notas"
         at: "Em"
         from: "De"
+    import:
+      success: "Itens importados com sucesso."
+      invalid: "Falha ao importar itens."
+      no_file: "Envie um arquivo CSV."
   locations:
     index:
       title: "Locais"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,8 @@ Rails.application.routes.draw do
       collection do
         get "search"
         get :find_by_barcode
+        get :import
+        post :import
         get :export
       end
 

--- a/spec/requests/items_spec.rb
+++ b/spec/requests/items_spec.rb
@@ -31,4 +31,38 @@ RSpec.describe "Items", type: :request do
       expect(response).to have_http_status(:unprocessable_entity)
     end
   end
+
+  describe "GET /teams/:team_id/items/import" do
+    it "shows the import form" do
+      get import_team_items_path(team)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "POST /teams/:team_id/items/import" do
+    let(:csv_content) do
+      "Name,SKU,Barcode,Type,Current Stock,Price,Cost,Brand\n" \
+        "CSV Item,CSV1,BC1,Type,1,2,1,Brand"
+    end
+
+    it "imports items" do
+      file = Tempfile.new(%w[items csv])
+      file.write(csv_content)
+      file.rewind
+
+      expect {
+        post import_team_items_path(team), params: { file: fixture_file_upload(file.path, 'text/csv') }
+      }.to change(Item, :count).by(1)
+
+      expect(response).to redirect_to(team_items_path(team))
+    ensure
+      file.close
+      file.unlink
+    end
+
+    it "rejects request without file" do
+      post import_team_items_path(team)
+      expect(response).to redirect_to(import_team_items_path(team))
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- enable CSV import from new ItemsController action
- handle file upload with a new view
- route GET/POST /import for items
- localize import messages in three languages
- test item import success and failures

## Testing
- `bin/rubocop` *(fails: version `ruby-3.2.2` is not installed)*
- `bin/brakeman --no-pager` *(fails: version `ruby-3.2.2` is not installed)*
- `bin/importmap audit` *(fails: version `ruby-3.2.2` is not installed)*
- `bin/rails db:test:prepare` *(fails: version `ruby-3.2.2` is not installed)*
- `bin/rails test` *(fails: version `ruby-3.2.2` is not installed)*
- `bundle exec rspec` *(fails: version `ruby-3.2.2` is not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6871069b2ab083339e2bb5fd2b76b09b