### PR TITLE
Add language switcher for login page

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,5 +1,8 @@
 <div class="min-h-screen w-full flex items-center justify-center bg-purple-50 absolute inset-0">
-  <div class="w-full max-w-md bg-white rounded-lg shadow-lg p-8 m-4">
+  <div class="w-full max-w-md bg-white rounded-lg shadow-lg p-8 m-4 relative">
+    <div class="absolute top-4 right-4">
+      <%= render 'shared/language_switcher' %>
+    </div>
     <div class="text-center mb-8">
       <div class="h-32 w-96 flex items-center justify-center mx-auto mb-4">
         <svg xmlns="http://www.w3.org/2000/svg" width="350" height="200" viewBox="0 0 350 200" class="w-full h-full">
@@ -23,12 +26,12 @@
     </div>
 
     <div class="w-full">
-      <h2 class="text-xl font-bold mb-2">Entrar</h2>
-      <p class="text-gray-600 text-base mb-8">Digite suas credenciais para acessar sua conta</p>
+      <h2 class="text-xl font-bold mb-2"><%= t('auth.sign_in.title') %></h2>
+      <p class="text-gray-600 text-base mb-8"><%= t('auth.sign_in.subtitle') %></p>
 
       <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "space-y-6" }) do |f| %>
         <div>
-          <%= f.label :email, "E-mail", class: "block text-sm font-bold mb-2 text-gray-700" %>
+          <%= f.label :email, t('auth.sign_in.email'), class: "block text-sm font-bold mb-2 text-gray-700" %>
           <%= f.email_field :email, autofocus: true, autocomplete: "email", 
               placeholder: "name@example.com",
               class: "w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-600 focus:border-transparent text-base" %>
@@ -36,21 +39,21 @@
 
         <div>
           <div class="flex items-center justify-between mb-2">
-            <%= f.label :password, "Senha", class: "block text-sm font-bold text-gray-700" %>
-            <%= link_to "Esqueceu a senha?", new_password_path(resource_name), 
+            <%= f.label :password, t('auth.sign_in.password'), class: "block text-sm font-bold text-gray-700" %>
+            <%= link_to t('auth.sign_in.forgot_password'), new_password_path(resource_name),
                 class: "text-sm text-purple-600 hover:text-purple-800 font-semibold" %>
           </div>
           <%= f.password_field :password, autocomplete: "current-password",
               class: "w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-600 focus:border-transparent text-base" %>
         </div>
 
-        <%= f.submit "Entrar", 
+        <%= f.submit t('auth.sign_in.submit'),
             class: "w-full bg-purple-600 text-white py-3 px-4 rounded-lg font-bold text-base hover:bg-purple-700 transition duration-200 ease-in-out mt-6" %>
       <% end %>
 
       <div class="mt-8 text-center text-base text-gray-600">
-        Não tem uma conta? 
-        <%= link_to "Cadastrar", new_registration_path(resource_name), 
+        <%= t('auth.sign_in.no_account') %>
+        <%= link_to t('auth.sign_in.register'), new_registration_path(resource_name),
             class: "text-purple-600 font-bold hover:text-purple-800" %>
       </div>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -541,3 +541,14 @@ en:
         not_a_number: "is not a number"
         must_be_selected: "must be selected"
         taken: "has already been taken"
+
+  auth:
+    sign_in:
+      title: "Sign In"
+      subtitle: "Enter your credentials to access your account"
+      email: "E-mail"
+      password: "Password"
+      forgot_password: "Forgot password?"
+      submit: "Sign In"
+      no_account: "Don\x27t have an account?"
+      register: "Register"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -37,7 +37,7 @@ fr:
       total_items: "Nombre Total d'Articles"
       total_transactions: "Nombre Total de Transactions"
       edit_team: "Modifier l'Équipe"
-      delete_team: "Supprimer l'Équipe"
+     delete_team: "Supprimer l'Équipe"
       delete_confirmation: "Êtes-vous sûr de vouloir supprimer cette équipe ?"
     form:
       errors:
@@ -470,3 +470,14 @@ fr:
         not_a_number: "n'est pas un nombre"
         must_be_selected: "doit être sélectionné"
         taken: "est déjà pris"
+
+  auth:
+    sign_in:
+      title: "Se connecter"
+      subtitle: "Entrez vos informations pour accéder à votre compte"
+      email: "E-mail"
+      password: "Mot de passe"
+      forgot_password: "Mot de passe oublié ?"
+      submit: "Se connecter"
+      no_account: "Vous n\x27avez pas de compte ?"
+      register: "S\x27inscrire"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -37,7 +37,7 @@ fr:
       total_items: "Nombre Total d'Articles"
       total_transactions: "Nombre Total de Transactions"
       edit_team: "Modifier l'Équipe"
-     delete_team: "Supprimer l'Équipe"
+      delete_team: "Supprimer l'Équipe"
       delete_confirmation: "Êtes-vous sûr de vouloir supprimer cette équipe ?"
     form:
       errors:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -489,7 +489,7 @@ pt-BR:
         blank: "não pode ficar em branco"
         not_a_number: "não é um número"
         must_be_selected: "deve ser selecionado"
-        taken: "já está em uso"
+             taken: "já está em uso"
       models:
         item:
           attributes:
@@ -511,3 +511,13 @@ pt-BR:
               must_belong_to_team: "deve pertencer à sua equipe"
             barcode:
               taken: "já está em uso" 
+  auth:
+    sign_in:
+      title: "Entrar"
+      subtitle: "Digite suas credenciais para acessar sua conta"
+      email: "E-mail"
+      password: "Senha"
+      forgot_password: "Esqueceu a senha?"
+      submit: "Entrar"
+      no_account: "Não tem uma conta?"
+      register: "Cadastrar"


### PR DESCRIPTION
## Summary
- show language switcher on the sign in page
- translate sign in page content

## Testing
- `bin/rubocop` *(fails: ruby 3.2.2 not installed)*
- `bin/brakeman --no-pager` *(fails: ruby 3.2.2 not installed)*
- `bin/importmap audit` *(fails: ruby 3.2.2 not installed)*
- `bin/rails db:test:prepare` *(fails: ruby 3.2.2 not installed)*
- `bin/rails test` *(fails: ruby 3.2.2 not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68719d770690833389c23612ea582a1f