### PR TITLE
Add token secured API

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,17 @@
+# Repository instructions
+
+## Commit style
+- Use a single short imperative line.
+
+## Checks before committing
+Run the following commands:
+1. `bin/rubocop`
+2. `bin/brakeman --no-pager`
+3. `bin/importmap audit`
+4. `bin/rails db:test:prepare`
+5. `bin/rails test`
+
+If commands fail because dependencies are missing, mention the limitation in the PR.
+
+## PR body
+Summarize notable changes with citations. Include a Testing section summarizing command results.

--- a/README.md
+++ b/README.md
@@ -77,3 +77,16 @@ Purple Stock is a comprehensive inventory management system designed for busines
 3. Make your changes and commit them
 4. Push to your fork
 5. Create a pull request
+
+## API
+
+### Authentication
+
+Include an `X-Api-Key` header with a valid token generated for a user.
+
+### Endpoints
+
+- `GET /api/v1/teams/:team_id/items` – list items
+- `GET /api/v1/teams/:team_id/items/:id` – show an item
+- `GET /api/v1/teams/:team_id/transactions` – list transactions
+- `POST /api/v1/teams/:team_id/transactions` – create a transaction

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,0 +1,15 @@
+class Api::V1::BaseController < ActionController::API
+  before_action :authenticate_api_key!
+
+  attr_reader :current_user
+
+  private
+
+  def authenticate_api_key!
+    token = request.headers['X-Api-Key']
+    api_key = ApiKey.find_by(token: token)
+    return head :unauthorized unless api_key
+
+    @current_user = api_key.user
+  end
+end

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -6,7 +6,7 @@ class Api::V1::BaseController < ActionController::API
   private
 
   def authenticate_api_key!
-    token = request.headers['X-Api-Key']
+    token = request.headers["X-Api-Key"]
     api_key = ApiKey.find_by(token: token)
     return head :unauthorized unless api_key
 

--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -1,0 +1,18 @@
+class Api::V1::ItemsController < Api::V1::BaseController
+  before_action :set_team
+
+  def index
+    render json: @team.items
+  end
+
+  def show
+    item = @team.items.find(params[:id])
+    render json: item
+  end
+
+  private
+
+  def set_team
+    @team = current_user.teams.find(params[:team_id])
+  end
+end

--- a/app/controllers/api/v1/transactions_controller.rb
+++ b/app/controllers/api/v1/transactions_controller.rb
@@ -1,0 +1,26 @@
+class Api::V1::TransactionsController < Api::V1::BaseController
+  before_action :set_team
+
+  def index
+    render json: @team.stock_transactions
+  end
+
+  def create
+    transaction = @team.stock_transactions.new(transaction_params.merge(user: current_user))
+    if transaction.save
+      render json: transaction, status: :created
+    else
+      render json: { errors: transaction.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_team
+    @team = current_user.teams.find(params[:team_id])
+  end
+
+  def transaction_params
+    params.require(:transaction).permit(:item_id, :quantity, :transaction_type, :source_location_id, :destination_location_id, :notes)
+  end
+end

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -1,3 +1,22 @@
+# == Schema Information
+#
+# Table name: api_keys
+#
+#  id         :bigint           not null, primary key
+#  token      :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_api_keys_on_token    (token) UNIQUE
+#  index_api_keys_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
 class ApiKey < ApplicationRecord
   belongs_to :user
   has_secure_token :token

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -1,0 +1,4 @@
+class ApiKey < ApplicationRecord
+  belongs_to :user
+  has_secure_token :token
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,6 +22,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   has_many :teams, dependent: :destroy
+  has_many :api_keys, dependent: :destroy
 
   # Patch for Devise session serialization bug in tests
   def self.serialize_from_session(key, salt = nil)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,15 @@ Rails.application.routes.draw do
     resource :settings, only: [ :show ]
     resources :locations
   end
+
+  namespace :api do
+    namespace :v1 do
+      resources :teams, only: [] do
+        resources :items, only: [:index, :show]
+        resources :transactions, only: [:index, :create]
+      end
+    end
+  end
   get "team_selection", to: "teams#selection"
 
   # Default root for non-authenticated users should be last

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,8 +63,8 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :teams, only: [] do
-        resources :items, only: [:index, :show]
-        resources :transactions, only: [:index, :create]
+        resources :items, only: [ :index, :show ]
+        resources :transactions, only: [ :index, :create ]
       end
     end
   end

--- a/db/migrate/20250324000000_create_api_keys.rb
+++ b/db/migrate/20250324000000_create_api_keys.rb
@@ -1,0 +1,10 @@
+class CreateApiKeys < ActiveRecord::Migration[8.0]
+  def change
+    create_table :api_keys do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :token, null: false
+      t.timestamps
+    end
+    add_index :api_keys, :token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_23_232144) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_24_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
   create_enum "stock_transaction_type", ["stock_in", "stock_out", "adjust", "move", "count"]
+
+  create_table "api_keys", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "token", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["token"], name: "index_api_keys_on_token", unique: true
+    t.index ["user_id"], name: "index_api_keys_on_user_id"
+  end
 
   create_table "items", force: :cascade do |t|
     t.string "name"
@@ -92,6 +101,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_23_232144) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "api_keys", "users"
   add_foreign_key "items", "locations"
   add_foreign_key "items", "teams"
   add_foreign_key "locations", "teams"

--- a/spec/factories/api_keys.rb
+++ b/spec/factories/api_keys.rb
@@ -1,3 +1,22 @@
+# == Schema Information
+#
+# Table name: api_keys
+#
+#  id         :bigint           not null, primary key
+#  token      :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_api_keys_on_token    (token) UNIQUE
+#  index_api_keys_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
 FactoryBot.define do
   factory :api_key do
     association :user

--- a/spec/factories/api_keys.rb
+++ b/spec/factories/api_keys.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :api_key do
+    association :user
+    token { SecureRandom.hex(16) }
+  end
+end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,3 +1,35 @@
+# == Schema Information
+#
+# Table name: items
+#
+#  id               :bigint           not null, primary key
+#  barcode          :string
+#  brand            :string
+#  cost             :decimal(10, 2)
+#  current_stock    :decimal(10, 2)   default(0.0)
+#  initial_quantity :integer          default(0)
+#  item_type        :string
+#  minimum_stock    :decimal(10, 2)   default(0.0)
+#  name             :string
+#  price            :decimal(10, 2)
+#  sku              :string
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  location_id      :bigint
+#  team_id          :bigint           not null
+#
+# Indexes
+#
+#  index_items_on_barcode      (barcode)
+#  index_items_on_location_id  (location_id)
+#  index_items_on_sku          (sku)
+#  index_items_on_team_id      (team_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (location_id => locations.id)
+#  fk_rails_...  (team_id => teams.id)
+#
 FactoryBot.define do
   factory :item do
     association :team

--- a/spec/factories/locations.rb
+++ b/spec/factories/locations.rb
@@ -1,3 +1,23 @@
+# == Schema Information
+#
+# Table name: locations
+#
+#  id          :bigint           not null, primary key
+#  description :text
+#  name        :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  team_id     :bigint           not null
+#
+# Indexes
+#
+#  index_locations_on_team_id           (team_id)
+#  index_locations_on_team_id_and_name  (team_id,name) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (team_id => teams.id)
+#
 FactoryBot.define do
   factory :location do
     association :team

--- a/spec/factories/stock_transactions.rb
+++ b/spec/factories/stock_transactions.rb
@@ -1,3 +1,37 @@
+# == Schema Information
+#
+# Table name: stock_transactions
+#
+#  id                      :bigint           not null, primary key
+#  notes                   :text
+#  quantity                :decimal(10, 2)   not null
+#  transaction_type        :enum             not null
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  destination_location_id :bigint
+#  item_id                 :bigint           not null
+#  source_location_id      :bigint
+#  team_id                 :bigint           not null
+#  user_id                 :bigint           not null
+#
+# Indexes
+#
+#  index_stock_transactions_on_destination_location_id  (destination_location_id)
+#  index_stock_transactions_on_item_id                  (item_id)
+#  index_stock_transactions_on_item_id_and_created_at   (item_id,created_at)
+#  index_stock_transactions_on_source_location_id       (source_location_id)
+#  index_stock_transactions_on_team_id                  (team_id)
+#  index_stock_transactions_on_transaction_type         (transaction_type)
+#  index_stock_transactions_on_user_id                  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (destination_location_id => locations.id)
+#  fk_rails_...  (item_id => items.id)
+#  fk_rails_...  (source_location_id => locations.id)
+#  fk_rails_...  (team_id => teams.id)
+#  fk_rails_...  (user_id => users.id)
+#
 FactoryBot.define do
   factory :stock_transaction do
     association :item

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,3 +1,35 @@
+# == Schema Information
+#
+# Table name: items
+#
+#  id               :bigint           not null, primary key
+#  barcode          :string
+#  brand            :string
+#  cost             :decimal(10, 2)
+#  current_stock    :decimal(10, 2)   default(0.0)
+#  initial_quantity :integer          default(0)
+#  item_type        :string
+#  minimum_stock    :decimal(10, 2)   default(0.0)
+#  name             :string
+#  price            :decimal(10, 2)
+#  sku              :string
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  location_id      :bigint
+#  team_id          :bigint           not null
+#
+# Indexes
+#
+#  index_items_on_barcode      (barcode)
+#  index_items_on_location_id  (location_id)
+#  index_items_on_sku          (sku)
+#  index_items_on_team_id      (team_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (location_id => locations.id)
+#  fk_rails_...  (team_id => teams.id)
+#
 require 'rails_helper'
 
 RSpec.describe Item, type: :model do

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -1,3 +1,23 @@
+# == Schema Information
+#
+# Table name: locations
+#
+#  id          :bigint           not null, primary key
+#  description :text
+#  name        :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  team_id     :bigint           not null
+#
+# Indexes
+#
+#  index_locations_on_team_id           (team_id)
+#  index_locations_on_team_id_and_name  (team_id,name) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (team_id => teams.id)
+#
 require 'rails_helper'
 
 RSpec.describe Location, type: :model do

--- a/spec/models/stock_transaction_spec.rb
+++ b/spec/models/stock_transaction_spec.rb
@@ -1,3 +1,37 @@
+# == Schema Information
+#
+# Table name: stock_transactions
+#
+#  id                      :bigint           not null, primary key
+#  notes                   :text
+#  quantity                :decimal(10, 2)   not null
+#  transaction_type        :enum             not null
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  destination_location_id :bigint
+#  item_id                 :bigint           not null
+#  source_location_id      :bigint
+#  team_id                 :bigint           not null
+#  user_id                 :bigint           not null
+#
+# Indexes
+#
+#  index_stock_transactions_on_destination_location_id  (destination_location_id)
+#  index_stock_transactions_on_item_id                  (item_id)
+#  index_stock_transactions_on_item_id_and_created_at   (item_id,created_at)
+#  index_stock_transactions_on_source_location_id       (source_location_id)
+#  index_stock_transactions_on_team_id                  (team_id)
+#  index_stock_transactions_on_transaction_type         (transaction_type)
+#  index_stock_transactions_on_user_id                  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (destination_location_id => locations.id)
+#  fk_rails_...  (item_id => items.id)
+#  fk_rails_...  (source_location_id => locations.id)
+#  fk_rails_...  (team_id => teams.id)
+#  fk_rails_...  (user_id => users.id)
+#
 require 'rails_helper'
 
 RSpec.describe StockTransaction, type: :model do

--- a/spec/requests/api_v1_items_spec.rb
+++ b/spec/requests/api_v1_items_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe 'API V1 Items', type: :request do
+  let(:user) { create(:user) }
+  let(:api_key) { create(:api_key, user: user) }
+  let(:team) { create(:team, user: user) }
+  let!(:location) { create(:location, team: team) }
+  let!(:items) { create_list(:item, 2, team: team, location: location) }
+
+  describe 'GET /api/v1/teams/:team_id/items' do
+    it 'returns items' do
+      get api_v1_team_items_path(team), headers: { 'X-Api-Key' => api_key.token }
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json.size).to eq(2)
+    end
+  end
+end

--- a/spec/requests/api_v1_transactions_spec.rb
+++ b/spec/requests/api_v1_transactions_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe 'API V1 Transactions', type: :request do
+  let(:user) { create(:user) }
+  let(:api_key) { create(:api_key, user: user) }
+  let(:team) { create(:team, user: user) }
+  let!(:location) { create(:location, team: team) }
+  let!(:item) { create(:item, team: team, location: location) }
+
+  describe 'POST /api/v1/teams/:team_id/transactions' do
+    it 'creates transaction' do
+      expect {
+        post api_v1_team_transactions_path(team),
+          params: { transaction: { item_id: item.id, quantity: 1, transaction_type: 'stock_in', destination_location_id: location.id } },
+          headers: { 'X-Api-Key' => api_key.token }
+      }.to change(StockTransaction, :count).by(1)
+      expect(response).to have_http_status(:created)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- expose API for items and transactions
- secure API with API keys
- route under `/api/v1`
- document API usage in README
- test API endpoints

## Testing
- `bin/rubocop` *(fails: `ruby-3.2.2` not installed)*
- `bin/brakeman --no-pager` *(fails: `ruby-3.2.2` not installed)*
- `bin/importmap audit` *(fails: `ruby-3.2.2` not installed)*
- `bin/rails db:test:prepare` *(fails: `ruby-3.2.2` not installed)*
- `bin/rails test` *(fails: `ruby-3.2.2` not installed)*

------
https://chatgpt.com/codex/tasks/task_b_687106e5c1e483339922a56ed8012836