### PR TITLE
Fix propshaft asset lookup

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -5,3 +5,6 @@ Rails.application.config.assets.version = "1.0"
 
 # Add additional assets to the asset load path.
 # Rails.application.config.assets.paths << Emoji.images_path
+
+# Include subdirectories for component-based stylesheets
+Rails.application.config.assets.paths << Rails.root.join("app/assets/stylesheets/components")


### PR DESCRIPTION
## Summary
- include the `components` styles directory in the asset load path

## Testing
- `bin/rubocop` *(fails: `ruby` not found)*
- `bin/brakeman --no-pager` *(fails: `ruby` not found)*
- `bin/importmap audit` *(fails: `ruby` not found)*
- `bin/rails db:test:prepare` *(fails: `ruby` not found)*
- `bin/rails test` *(fails: `ruby` not found)*

------
https://chatgpt.com/codex/tasks/task_b_688a520279188333b6df2cc302ad01b9