### PR TITLE
Add item components for kit management and enhance stock transaction …

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -28,6 +28,8 @@ class ItemsController < ApplicationController
 
   def new
     @item = @team.items.build
+    @locations = @team.locations.ordered
+    3.times { @item.kit_components.build }
   end
 
   def create
@@ -44,6 +46,7 @@ class ItemsController < ApplicationController
 
   def edit
     @locations = @team.locations.ordered
+    @item.kit_components.build while @item.kit_components.size < 3
   end
 
   def update
@@ -198,7 +201,8 @@ class ItemsController < ApplicationController
 
   def item_params
     params.require(:item).permit(:sku, :name, :barcode, :cost, :price,
-                               :item_type, :brand, :location_id)
+                               :item_type, :brand, :location_id,
+                               kit_components_attributes: [ :id, :component_item_id, :quantity, :_destroy ])
   end
 
   def trigger_webhook(event, item)

--- a/app/models/item_component.rb
+++ b/app/models/item_component.rb
@@ -1,0 +1,26 @@
+class ItemComponent < ApplicationRecord
+  belongs_to :team
+  belongs_to :kit_item, class_name: "Item"
+  belongs_to :component_item, class_name: "Item"
+
+  validates :quantity, presence: true, numericality: { greater_than: 0 }
+  validate :kit_and_component_must_belong_to_same_team
+  validate :kit_and_component_cannot_be_same
+
+  private
+
+  def kit_and_component_must_belong_to_same_team
+    return if kit_item.blank? || component_item.blank? || team.blank?
+    if kit_item.team_id != team_id || component_item.team_id != team_id
+      errors.add(:base, "Kit and component must belong to the same team")
+    end
+  end
+
+  def kit_and_component_cannot_be_same
+    return if kit_item_id.blank? || component_item_id.blank?
+    if kit_item_id == component_item_id
+      errors.add(:component_item_id, "cannot be the same as kit item")
+    end
+  end
+end
+

--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -79,8 +79,49 @@
     </div>
   </div>
 
+  <%# Kit components section (optional) %>
+  <%# Render only if the item is/will be a kit (by convention: item_type == 'kit') %>
+  <% if item.item_type&.downcase == 'kit' || item.kit_components.any? %>
+    <div class="mt-10 bg-white p-6 rounded-lg border">
+      <h3 class="text-lg font-medium text-gray-900 mb-4">Kit Components</h3>
+      <p class="text-sm text-gray-500 mb-4">Select items and quantities that compose this kit.</p>
+
+      <div class="space-y-4">
+        <div class="grid grid-cols-12 gap-4 font-semibold text-gray-600">
+          <div class="col-span-7">Item</div>
+          <div class="col-span-3">Quantity</div>
+          <div class="col-span-2"></div>
+        </div>
+
+        <div class="space-y-3">
+          <%= f.fields_for :kit_components do |kc| %>
+            <div class="grid grid-cols-12 gap-4 items-center">
+              <div class="col-span-7">
+                <%= kc.collection_select :component_item_id,
+                      @team.items.where.not(id: item.id).order(:name),
+                      :id, :name,
+                      { include_blank: 'Select item' },
+                      class: 'mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm' %>
+              </div>
+              <div class="col-span-3">
+                <%= kc.number_field :quantity, step: '0.01', min: 0.01,
+                      class: 'mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm' %>
+              </div>
+              <div class="col-span-2">
+                <label class="inline-flex items-center space-x-2 text-sm">
+                  <%= kc.check_box :_destroy %>
+                  <span>Remove</span>
+                </label>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  <% end %>
+
   <div class="flex justify-end space-x-3 mt-6">
     <%= link_to t('items.form.buttons.cancel'), team_items_path(@team), class: "btn btn-secondary" %>
     <%= f.submit class: "btn btn-primary" %>
   </div>
-<% end %> 
+<% end %>

--- a/db/migrate/20250915090000_create_item_components.rb
+++ b/db/migrate/20250915090000_create_item_components.rb
@@ -1,0 +1,15 @@
+class CreateItemComponents < ActiveRecord::Migration[8.0]
+  def change
+    create_table :item_components do |t|
+      t.references :team, null: false, foreign_key: true
+      t.references :kit_item, null: false, foreign_key: { to_table: :items }
+      t.references :component_item, null: false, foreign_key: { to_table: :items }
+      t.decimal :quantity, precision: 10, scale: 2, null: false
+
+      t.timestamps
+    end
+
+    add_index :item_components, [:kit_item_id, :component_item_id], unique: true
+  end
+end
+


### PR DESCRIPTION
Resumo da Mudança

- Adicionado suporte a itens agrupados como “kits” (lotes/combos) usando uma composição de itens.
- Um kit é um Item que possui componentes e suas quantidades através de ItemComponent.
- Saída de estoque de um kit desconta automaticamente o estoque de cada componente proporcionalmente.
- Estoque “atual” de um kit passa a ser derivado como o mínimo entre (estoque de cada componente / quantidade exigida).
- Formulário de Item atualizado para permitir gerenciar componentes quando o item_type for “kit”.

Detalhes Técnicos

- Novo modelo ItemComponent:
    - Associações: belongs_to :team, belongs_to :kit_item, class_name: 'Item', belongs_to :component_item, class_name: 'Item'.
    - Validações: quantidade > 0; kit e componente no mesmo time; não pode referenciar o mesmo item.
- Migração db/migrate/20250915090000_create_item_components.rb:
    - Cria tabela item_components com team_id, kit_item_id, component_item_id, quantity:decimal(10,2), índices e FKs.
- Item:
    - Associações de kit: has_many :kit_components, has_many :components, through: :kit_components, além de reverse_kit_components e used_in_kits.
    - accepts_nested_attributes_for :kit_components, allow_destroy: true.
    - current_stock agora retorna “estoque derivado” para kits, calculado por kit_available_stock.
    - kit? indica kit se houver componentes.
- ItemsController:
    - new e edit constroem linhas iniciais para componentes (3 linhas).
    - Strong params permite kit_components_attributes: [:id, :component_item_id, :quantity, :_destroy].
- StockTransactionsController:
    - Em stock_out (POST) e no create com transaction_type == "stock_out":
    - Se o item é kit, valida disponibilidade de todos os componentes e cria transações de saída negativas para cada componente em vez do kit.
    - Notas incluem referência ao kit para rastreabilidade.
    - Continua suportando item simples sem alterações no fluxo.
- app/views/items/_form.html.erb:
    - Se item_type é “kit” (ou se já possui componentes), exibe seção para gerenciar componentes com select de item e quantidade, além de checkbox de remoção.

Como usar (Fluxo)

- Cadastre/edite um Item com item_type = "kit".
- Na seção “Kit Components” selecione itens componentes e quantidades.
- Ao realizar saída de estoque e selecionar o kit, o sistema desconta os componentes conforme as quantidades configuradas.
- A disponibilidade exibida de um kit passa a refletir o mínimo combinável dos componentes.

Limitações e Próximos Passos

- O fluxo de “entrada” e “ajuste” não realiza “montagem” de kits (não converte componentes em kits automaticamente). Se desejar, posso implementar um fluxo de montagem/desmontagem de kits.
- Movimentação entre locais (“move”) de kits não expande para componentes; atualmente, recomendo mover componentes diretamente. Posso implementar expansão também para “move” se necessário.
- UI de busca/listagem ainda mostra “Stock” do kit via current_stock derivado; isso deve ser suficiente, mas posso adicionar rótulos visuais “Kit” e exibir a composição na tela do item.
- Não há validação de circularidade (kit dentro de kit recursivo). Podemos adicionar se for requisito.

Checks antes do commit

- bin/rubocop: falhou por gems ausentes no ambiente local (“Could not find ... in locally installed gems”).
- bin/brakeman --no-pager: não executado devido à mesma limitação de dependências.
- bin/importmap audit: não executado pela limitação.
- bin/rails db:test:prepare e bin/rails test: não executados por dependências/DB não configurados no sandbox.

Se quiser, executo essas verificações localmente quando as dependências estiverem instaladas (bundle install, DB up). Posso também ajustar o fluxo para “move” e “stock_in” com kits (montagem) conforme sua preferência.

Commits

- Mensagem sugerida: “Add item kits via ItemComponent and expand stock_out to components”

Arquivos alterados

- Added: app/models/item_component.rb
- Added: db/migrate/20250915090000_create_item_components.rb
- Updated: app/models/item.rb (associações, cálculo de estoque de kit)
- Updated: app/controllers/items_controller.rb (nested attrs e preparação de form)
- Updated: app/controllers/stock_transactions_controller.rb (expansão de kits no stock_out)
- Updated: app/views/items/_form.html.erb (seção de componentes para kits)

Quer que eu também:

- Adicione a expansão de kits no “move”?
- Implemente montagem/desmontagem (stock_in de kit consome componentes)?